### PR TITLE
fix: Remove links to RSS feeds from HEAD tag

### DIFF
--- a/material/main.html
+++ b/material/main.html
@@ -2,7 +2,3 @@
   This file was automatically generated - do not edit
 -#}
 {% extends "base.html" %}
-{% block extrahead %}
-  <link rel="alternate" type="application/rss+xml" title="RSS feed of new documentation pages" href="/feed_rss_created.xml">
-  <link rel="alternate" type="application/rss+xml" title="RSS feed of updated documentation pages" href="/feed_rss_updated.xml">
-{% endblock %}

--- a/src/main.html
+++ b/src/main.html
@@ -21,9 +21,3 @@
 -->
 
 {% extends "base.html" %}
-
-{% block extrahead %}
-  <!-- RSS Feed -->
-  <link rel="alternate" type="application/rss+xml" title="RSS feed of new documentation pages" href="/feed_rss_created.xml">
-  <link rel="alternate" type="application/rss+xml" title="RSS feed of updated documentation pages" href="/feed_rss_updated.xml">
-{% endblock %}


### PR DESCRIPTION
Since the RSS feeds ended up not working after all, these links are broken and should be removed.