### PR TITLE
fix: Use tracker object to send Google Analytics events DOCS-175

### DIFF
--- a/material/partials/integrations/feedback.html
+++ b/material/partials/integrations/feedback.html
@@ -31,16 +31,16 @@
       noButton.disabled = true;
     };
     const sendFeedback = (value) => {
-      if (typeof ga !== 'function') return;
+      if (typeof tracker === 'undefined' || typeof tracker.send !== 'function') return;
       const args = {
-        command: 'send',
-        hitType: 'event',
         category: 'User Feedback',
         action: 'click',
         label: window.location.pathname,
         value: value
       };
-      ga(args.command, args.hitType, args.category, args.action, args.label, args.value);
+      // Send an event to Google Analytics
+      // https://developers.google.com/analytics/devguides/collection/analyticsjs/tracker-object-reference#send
+      tracker.send(args.category, args.action, args.label, args.value);
     };
     yesButton.addEventListener('click', () => {
       yesResponse.classList.add('user-feedback-response--visible');

--- a/src/partials/integrations/feedback.html
+++ b/src/partials/integrations/feedback.html
@@ -60,16 +60,16 @@
       noButton.disabled = true;
     };
     const sendFeedback = (value) => {
-      if (typeof ga !== 'function') return;
+      if (typeof tracker === 'undefined' || typeof tracker.send !== 'function') return;
       const args = {
-        command: 'send',
-        hitType: 'event',
         category: 'User Feedback',
         action: 'click',
         label: window.location.pathname,
         value: value
       };
-      ga(args.command, args.hitType, args.category, args.action, args.label, args.value);
+      // Send an event to Google Analytics
+      // https://developers.google.com/analytics/devguides/collection/analyticsjs/tracker-object-reference#send
+      tracker.send(args.category, args.action, args.label, args.value);
     };
     yesButton.addEventListener('click', () => {
       yesResponse.classList.add('user-feedback-response--visible');


### PR DESCRIPTION
The original method to send events from #7 was not working.