### PR TITLE
fix: Obtain missing Tracker object DOCS-175

### DIFF
--- a/material/partials/integrations/feedback.html
+++ b/material/partials/integrations/feedback.html
@@ -31,16 +31,16 @@
       noButton.disabled = true;
     };
     const sendFeedback = (value) => {
-      if (typeof tracker === 'undefined' || typeof tracker.send !== 'function') return;
+      if (typeof ga !== "function" || ga.getAll().length === 0 ) return;
       const args = {
-        category: 'User Feedback',
-        action: 'click',
+        category: "User Feedback",
+        action: "click",
         label: window.location.pathname,
         value: value
       };
       // Send an event to Google Analytics
       // https://developers.google.com/analytics/devguides/collection/analyticsjs/tracker-object-reference#send
-      tracker.send(args.category, args.action, args.label, args.value);
+      ga.getAll()[0].send(args.category, args.action, args.label, args.value);
     };
     yesButton.addEventListener('click', () => {
       yesResponse.classList.add('user-feedback-response--visible');

--- a/src/partials/integrations/feedback.html
+++ b/src/partials/integrations/feedback.html
@@ -60,16 +60,16 @@
       noButton.disabled = true;
     };
     const sendFeedback = (value) => {
-      if (typeof tracker === 'undefined' || typeof tracker.send !== 'function') return;
+      if (typeof ga !== "function" || ga.getAll().length === 0 ) return;
       const args = {
-        category: 'User Feedback',
-        action: 'click',
+        category: "User Feedback",
+        action: "click",
         label: window.location.pathname,
         value: value
       };
-      // Send an event to Google Analytics
+      // Send an event to Google Analytics using the default Tracker object
       // https://developers.google.com/analytics/devguides/collection/analyticsjs/tracker-object-reference#send
-      tracker.send(args.category, args.action, args.label, args.value);
+      ga.getAll()[0].send(args.category, args.action, args.label, args.value);
     };
     yesButton.addEventListener('click', () => {
       yesResponse.classList.add('user-feedback-response--visible');


### PR DESCRIPTION
The change from #8 didn't work, as I didn't realize the `Tracker` object had to be explicitly obtained from the `ga` object.