### PR TITLE
fix: Avoid hardcoded repository URL DOCS-179

### DIFF
--- a/material/partials/integrations/feedback.html
+++ b/material/partials/integrations/feedback.html
@@ -18,7 +18,7 @@
     Thank you for the feedback!
     </p>
     <p class="user-feedback-response user-feedback-response--no">
-    We're sorry to hear that. Please <a target="_blank" href="https://github.com/codacy/docs/issues/new?labels=user%20feedback&template=documentation-feedback.md&title=Feedback%20on%20%22{{ page.title }}%22">let us know what we can improve</a>.
+    We're sorry to hear that. Please <a target="_blank" href="{{ config.repo_url }}/issues/new?labels=user%20feedback&template=documentation-feedback.md&title=Feedback%20on%20%22{{ page.title }}%22">let us know what we can improve</a>.
     </p>  
   </div>
   <script>

--- a/src/partials/integrations/feedback.html
+++ b/src/partials/integrations/feedback.html
@@ -47,7 +47,7 @@
     Thank you for the feedback!
     </p>
     <p class="user-feedback-response user-feedback-response--no">
-    We're sorry to hear that. Please <a target="_blank" href="https://github.com/codacy/docs/issues/new?labels=user%20feedback&template=documentation-feedback.md&title=Feedback%20on%20%22{{ page.title }}%22">let us know what we can improve</a>.
+    We're sorry to hear that. Please <a target="_blank" href="{{ config.repo_url }}/issues/new?labels=user%20feedback&template=documentation-feedback.md&title=Feedback%20on%20%22{{ page.title }}%22">let us know what we can improve</a>.
     </p>  
   </div>
   <script>


### PR DESCRIPTION
Improves https://github.com/codacy/codacy-mkdocs-material/pull/7 by using the variable defined on `mkdocs.yml` for the repository URL instead of a hardcoded value.