### PR TITLE
feature: Enable user feedback block dynamically on mkdocs.yml

### DIFF
--- a/material/partials/integrations/feedback.html
+++ b/material/partials/integrations/feedback.html
@@ -1,7 +1,7 @@
 {#-
   This file was automatically generated - do not edit
 -#}
-{% if not page.is_homepage %}
+{% if config.extra.user_feedback == "true" and not page.is_homepage %}
   <style>.user-feedback-answer{background-color:var(--md-accent-fg-color--transparent);border-radius:.3em;color:var(--codacy-neutral-600);display:inline-block;font:inherit;font-size:.9em;padding:.2em;width:6em}.user-feedback-answer .svg-icon{display:inline-block;margin-right:.5em;vertical-align:top;width:1.3em}.user-feedback-answer:disabled{background-color:var(--md-default-fg-color--lightest)}.user-feedback-answer--no{margin-left:1em}.user-feedback-response{display:none}.user-feedback-response--visible{display:block}</style>  
   <div id="user-feedback">
     <h2 id="user-feedback-title">Feedback</h2>

--- a/src/partials/integrations/feedback.html
+++ b/src/partials/integrations/feedback.html
@@ -1,5 +1,10 @@
-<!-- User feedback -->
-{% if not page.is_homepage %}
+<!-- User feedback
+     Must be enabled on mkdocs.yml:
+     
+     extra:
+       user_feedback: "true"
+-->
+{% if config.extra.user_feedback == "true" and not page.is_homepage %}
   <style>
     .user-feedback-answer {
       background-color: var(--md-accent-fg-color--transparent);


### PR DESCRIPTION
Improves https://github.com/codacy/codacy-mkdocs-material/pull/7 by enabling the feedback block dynamically depending on the following setting on `mkdocs.yml`:

```yml
extra:
  user_feedback: "true"
```

This will enable us to turn off the feedback block when using the theme on other documentation bases besides product documentation.