### PR TITLE
fix: Rename feedback anchor link

### DIFF
--- a/material/partials/integrations/feedback.html
+++ b/material/partials/integrations/feedback.html
@@ -4,7 +4,7 @@
 {% if config.extra.user_feedback == "true" and not page.is_homepage %}
   <style>.user-feedback-answer{background-color:var(--md-accent-fg-color--transparent);border-radius:.3em;color:var(--codacy-neutral-600);display:inline-block;font:inherit;font-size:.9em;padding:.2em;width:6em}.user-feedback-answer .svg-icon{display:inline-block;margin-right:.5em;vertical-align:top;width:1.3em}.user-feedback-answer:disabled{background-color:var(--md-default-fg-color--lightest)}.user-feedback-answer--no{margin-left:1em}.user-feedback-response{display:none}.user-feedback-response--visible{display:block}</style>  
   <div id="user-feedback">
-    <h2 id="user-feedback-title">Feedback</h2>
+    <h2 id="feedback">Feedback</h2>
     <p>Did this page help you?</p>
     <button class="user-feedback-answer user-feedback-answer--yes md-icon">
     <span class="svg-icon">{% set icon = "material/check" %}

--- a/src/partials/integrations/feedback.html
+++ b/src/partials/integrations/feedback.html
@@ -36,7 +36,7 @@
     }
   </style>  
   <div id="user-feedback">
-    <h2 id="user-feedback-title">Feedback</h2>
+    <h2 id="feedback">Feedback</h2>
     <p>Did this page help you?</p>
 
     <button class="user-feedback-answer user-feedback-answer--yes md-icon">


### PR DESCRIPTION
This makes the ID consistent with the ids for all other section titles in the documentation pages.