### PR TITLE
fix: Use config.extra.support_contact instead of config.site_author

### DIFF
--- a/src/partials/integrations/feedback.html
+++ b/src/partials/integrations/feedback.html
@@ -60,7 +60,7 @@
     </p>
 
     <p>
-      If you have a question, please <a href="{{ config.extra.community_url }}">ask our community</a> or contact <a href="mailto:{{ config.extra.support_contact }}?subject=Question%20regarding%20{{ page.title }}">{{ config.site_author }}</a>.
+      If you have a question, please <a href="{{ config.extra.community_url }}">ask our community</a> or contact <a href="mailto:{{ config.extra.support_contact }}?subject=Question%20regarding%20{{ page.title }}">{{ config.extra.support_contact }}</a>.
     </p>
   </div>
   <script>


### PR DESCRIPTION
The variable `config.site_author` [now contains the "real name" of the contact](https://github.com/codacy/docs/blob/9bc6a8ef7bb49159e6280ab2581f23fe5b4a92e4/mkdocs.yml#L5), so we use the variable `config.extra.support_contact` to contain only the email address.