### PR TITLE
feature: Allow hiding the TOC on specific pages

### DIFF
--- a/material/partials/toc.html
+++ b/material/partials/toc.html
@@ -7,7 +7,7 @@
   {% if toc | first is defined and "\x3ch1 id=" in page.content %}
     {% set toc = (toc | first).children %}
   {% endif %}
-  {% if toc | first is defined %}
+  {% if toc | first is defined and not page.meta.hide_toc %}
     <ul class="md-nav__list" data-md-scrollfix>
       {% for toc_item in toc %}
         {% include "partials/toc-item.html" %}

--- a/src/partials/toc.html
+++ b/src/partials/toc.html
@@ -37,7 +37,7 @@
   {% endif %}
 
   <!-- Render item list -->
-  {% if toc | first is defined %}
+  {% if toc | first is defined and not page.meta.hide_toc %}
     <!-- <label class="md-nav__title">
       <span class="md-nav__icon md-icon">
         {% include ".icons/material/arrow-left.svg" %}


### PR DESCRIPTION
Use the following in the page metadata to disable the TOC:

```
---
hide_toc: true
---
```

Originally used in https://github.com/codacy/docs/pull/797.