### PR TITLE
clean: Stop recommending the Community for help requests

### DIFF
--- a/src/partials/integrations/feedback.html
+++ b/src/partials/integrations/feedback.html
@@ -134,7 +134,7 @@
     </p>
 
     <p>
-      If you have a question or need help, please <a href="{{ config.extra.community_url }}">ask our community</a> or contact <a href="mailto:{{ config.extra.support_email }}?subject=Question%20regarding%20{{ page.title }}">{{ config.extra.support_email }}</a>.
+      If you have a question or need help please contact <a href="mailto:{{ config.extra.support_email }}?subject=Question%20regarding%20{{ page.title }}">{{ config.extra.support_email }}</a>.
     </p>
   </div>
   <script>


### PR DESCRIPTION
Since [we cannot assure a timely reply](https://community.codacy.com/t/do-you-need-help-with-an-urgent-issue-please-contact-support/707/3) to customers who ask questions on the Community, I believe it's better not to recommend users to ask questions there and to contact Support directly.

**Before:**

![image](https://user-images.githubusercontent.com/60105800/146532656-2d6b101a-f3d5-4c84-9207-7186ccf91216.png)

**After:**

![image](https://user-images.githubusercontent.com/60105800/146541756-0190142f-3505-41a2-b709-accca3258e99.png)
