### PR TITLE
clean: Remove link to Community from feedback block DOCS-360

### DIFF
--- a/material/partials/integrations/feedback.html
+++ b/material/partials/integrations/feedback.html
@@ -45,7 +45,7 @@
       Thanks for helping improve the Codacy documentation.
     </p>
     <p>
-      If you have a question or need help, you can <a href="{{ config.extra.community_url }}">try looking for answers on our community</a> or contact <a href="mailto:{{ config.extra.support_email }}?subject=Question%20regarding%20{{ page.title }}">{{ config.extra.support_email }}</a>.
+      If you have a question or need help please contact <a href="mailto:{{ config.extra.support_email }}?subject=Question%20regarding%20{{ page.title }}">{{ config.extra.support_email }}</a>.
     </p>
   </div>
   <script>

--- a/src/partials/integrations/feedback.html
+++ b/src/partials/integrations/feedback.html
@@ -134,7 +134,7 @@
     </p>
 
     <p>
-      If you have a question or need help, you can <a href="{{ config.extra.community_url }}">try looking for answers on our community</a> or contact <a href="mailto:{{ config.extra.support_email }}?subject=Question%20regarding%20{{ page.title }}">{{ config.extra.support_email }}</a>.
+      If you have a question or need help please contact <a href="mailto:{{ config.extra.support_email }}?subject=Question%20regarding%20{{ page.title }}">{{ config.extra.support_email }}</a>.
     </p>
   </div>
   <script>


### PR DESCRIPTION
See [DOCS-360](https://codacy.atlassian.net/browse/DOCS-360) for the reasoning behind removing the link.