### PR TITLE
toolchain: Add @codacy/techwriters as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @prcr
+* @codacy/techwriters


### PR DESCRIPTION
Adds the GitHub group @codacy/techwriters as CODEOWNERS of the repository.