### PR TITLE
feat: Disclaimer for old documentation versions DOCS-81

### DIFF
--- a/material/base.html
+++ b/material/base.html
@@ -129,7 +129,7 @@
             <article class="md-content__inner md-typeset">
               <div class="admonition important" style="margin-top: 0">
                 <div class="admonition-title">This is an archived version of the documentation for Codacy
-                  {% if config.extra and config.extra.version %}
+                  {% if config.extra.version %}
                     Self-hosted v{{ config.extra.version }}.
                   {% else %}
                     Self-hosted.

--- a/material/base.html
+++ b/material/base.html
@@ -127,6 +127,16 @@
         <div class="md-main__inner">
           <div class="md-content">
             <article class="md-content__inner md-typeset">
+              <div class="admonition important" style="margin-top: 0">
+                <div class="admonition-title">This is an archived version of the documentation for Codacy
+                  {% if config.extra and config.extra.version %}
+                    Self-hosted v{{ config.extra.version }}.
+                  {% else %}
+                    Self-hosted.
+                  {% endif %}
+                </div>
+                <p>See the documentation for the <a href="https://docs.codacy.com/">latest Cloud version</a>.</p>
+              </div>
               {% block content %}
                 {% block source %}
                   {% if page and page.meta and page.meta.source %}

--- a/material/base.html
+++ b/material/base.html
@@ -129,15 +129,14 @@
             <article class="md-content__inner md-typeset">
               {% if config.extra.self_hosted %}
                 <div class="admonition important" style="margin-top: 0">
-                  <div class="admonition-title">This is the Codacy Self-hosted
+                  <div class="admonition-title">This documentation applies to Codacy Self-hosted
                     {% if config.extra.version %}
                       v{{ config.extra.version }}
                     {% endif %}
-                    documentation
                   </div>
                   <p>
                     For the latest updates and improvements,
-                    see the <a href="https://docs.codacy.com/">latest Cloud documentation</a> instead.
+                    <a href="https://docs.codacy.com/">see the latest Cloud documentation</a> instead.
                   </p>
                 </div>
               {% endif %}

--- a/material/base.html
+++ b/material/base.html
@@ -128,14 +128,14 @@
           <div class="md-content">
             <article class="md-content__inner md-typeset">
               <div class="admonition important" style="margin-top: 0">
-                <div class="admonition-title">This is an archived version of the documentation for Codacy
+                <div class="admonition-title">These are the archived docs for Codacy
                   {% if config.extra.version %}
-                    Self-hosted v{{ config.extra.version }}.
+                    Self-hosted v{{ config.extra.version }}
                   {% else %}
-                    Self-hosted.
+                    Self-hosted
                   {% endif %}
                 </div>
-                <p>See the documentation for the <a href="https://docs.codacy.com/">latest Cloud version</a>.</p>
+                <p>For the latest updates and improvements, see the <a href="https://docs.codacy.com/">latest Cloud docs</a> instead.</p>
               </div>
               {% block content %}
                 {% block source %}

--- a/material/base.html
+++ b/material/base.html
@@ -127,16 +127,20 @@
         <div class="md-main__inner">
           <div class="md-content">
             <article class="md-content__inner md-typeset">
-              <div class="admonition important" style="margin-top: 0">
-                <div class="admonition-title">These are the archived docs for Codacy
-                  {% if config.extra.version %}
-                    Self-hosted v{{ config.extra.version }}
-                  {% else %}
-                    Self-hosted
-                  {% endif %}
+              {% if config.extra.self_hosted %}
+                <div class="admonition important" style="margin-top: 0">
+                  <div class="admonition-title">This is the Codacy Self-hosted
+                    {% if config.extra.version %}
+                      v{{ config.extra.version }}
+                    {% endif %}
+                    documentation
+                  </div>
+                  <p>
+                    For the latest updates and improvements,
+                    see the <a href="https://docs.codacy.com/">latest Cloud documentation</a> instead.
+                  </p>
                 </div>
-                <p>For the latest updates and improvements, see the <a href="https://docs.codacy.com/">latest Cloud docs</a> instead.</p>
-              </div>
+              {% endif %}
               {% block content %}
                 {% block source %}
                   {% if page and page.meta and page.meta.source %}


### PR DESCRIPTION
We want to add an "archived documentation" note/banner on all pages for previous (i.e. Self-hosted) versions.

### ☑️  To do
We'll work in stages, deciding on the copy and then fixing the logic.
- [x] Banner copy
- [x] Display logic
- [ ] Generate SH doc versions